### PR TITLE
fix: use pathToFileURL for dynamic imports on Windows

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -1,7 +1,7 @@
 import { REST, Routes } from 'discord.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import config from './config/index.js';
 
 const { CLIENT_ID: cliendId, DISCORD_TOKEN: discordToken } = config;
@@ -27,7 +27,7 @@ const commandFolders = fs.readdirSync(foldersPath);
       console.info(filePath);
 
       // eslint-disable-next-line no-await-in-loop
-      const command = (await import(filePath)).default;
+      const command = (await import(pathToFileURL(filePath).href)).default;
 
       if ('data' in command && 'execute' in command) {
         commands.push(command.data.toJSON());

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { Collection, userMention } from 'discord.js';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import client from './client/index.js';
 import config from './config/index.js';
 import mongoDBConnect from './lib/mongo-db.js';
@@ -27,7 +27,7 @@ for (const folder of commandFolders) {
     const filePath = path.join(commandsPath, file);
 
     (async () => {
-      const command = (await import(filePath)).default;
+      const command = (await import(pathToFileURL(filePath).href)).default;
 
       if ('data' in command && 'execute' in command) {
         client.commands.set(command.data.name, command);
@@ -49,7 +49,7 @@ for (const file of eventFiles) {
   const filePath = path.join(eventsPath, file);
 
   (async () => {
-    const event = (await import(filePath)).default;
+    const event = (await import(pathToFileURL(filePath).href)).default;
 
     if (event.once) {
       client.once(event.name, (...args) => event.execute(...args));


### PR DESCRIPTION
## Summary
- Fix ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows when loading commands and events via dynamic import()
- Use pathToFileURL() in src/index.js and src/deploy-commands.js

Closes #31

## Test plan
- [x] npm run deploy-commands:dev succeeds on Windows (Node v20)
- [x] npm run dev starts and loads commands/events on Windows
- [ ] No regression on Linux/macOS