### PR TITLE
Added multiword submission

### DIFF
--- a/src/commands/categories/create-new-category.js
+++ b/src/commands/categories/create-new-category.js
@@ -4,7 +4,7 @@ import createNewCategory from '../../service/interaction/is-chat-input-command/c
 export default {
   data: new SlashCommandBuilder()
     .setName('create-new-category')
-    .setDescription('Create new category')
+    .setDescription('Create one or more categories (one per line)')
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 
   async execute(interaction) {

--- a/src/commands/match-match/create-a-new-match-match-topic.js
+++ b/src/commands/match-match/create-a-new-match-match-topic.js
@@ -4,7 +4,7 @@ import createANewMatchMatchTopic from '../../service/interaction/is-chat-input-c
 export default {
   data: new SlashCommandBuilder()
     .setName('create-a-new-match-match-topic')
-    .setDescription('Create new match match topic')
+    .setDescription('Create one or more match match topics (one per line)')
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 
   async execute(interaction) {

--- a/src/service/interaction/is-chat-input-command/create-a-new-match-match-topic.js
+++ b/src/service/interaction/is-chat-input-command/create-a-new-match-match-topic.js
@@ -3,11 +3,12 @@ import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from
 export default async (interaction) => {
   const modal = new ModalBuilder()
     .setCustomId('create-a-new-match-match-topic')
-    .setTitle('Create new match-match topic');
+    .setTitle('Create new match-match topic(s)');
 
   const topic = new TextInputBuilder()
     .setCustomId('topic')
-    .setLabel('Put a topic to create')
+    .setLabel('Topics to create, one per line')
+    .setPlaceholder('Animals\nCountries\nFood and drinks')
     .setStyle(TextInputStyle.Paragraph);
 
   modal.addComponents(new ActionRowBuilder().addComponents(topic));

--- a/src/service/interaction/is-chat-input-command/create-new-category.js
+++ b/src/service/interaction/is-chat-input-command/create-new-category.js
@@ -3,11 +3,12 @@ import { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } from
 export default async (interaction) => {
   const modal = new ModalBuilder()
     .setCustomId('create-new-category')
-    .setTitle('Create new category');
+    .setTitle('Create new category (categories)');
 
   const message = new TextInputBuilder()
     .setCustomId('message')
-    .setLabel('Put message content')
+    .setLabel('Categories to create, one per line')
+    .setPlaceholder('Types of fruit\nThings found in a kitchen\nCity names')
     .setStyle(TextInputStyle.Paragraph);
 
   modal.addComponents(new ActionRowBuilder().addComponents(message));

--- a/src/service/interaction/is-modal-submit/create-a-new-match-match-topic.js
+++ b/src/service/interaction/is-modal-submit/create-a-new-match-match-topic.js
@@ -1,46 +1,71 @@
 import { COLORS } from '../../../constants/index.js';
 import MatchMatchTopic from '../../../models/match-match-topic.js';
+import { formatBulkList, parseBulkLines } from '../../utils/parse-bulk-lines.js';
+
+const replyWithEmbed = (interaction, description) =>
+  interaction.reply({
+    embeds: [
+      {
+        color: COLORS.PRIMARY,
+        description,
+      },
+    ],
+    ephemeral: true,
+  });
 
 export default async (interaction) => {
   try {
-    const topic = interaction.fields.getTextInputValue('topic');
+    const input = interaction.fields.getTextInputValue('topic');
+    const { entries, duplicateInInputCount } = parseBulkLines(input);
 
-    const res = await MatchMatchTopic.create({
-      topic,
-    });
-
-    if (res) {
-      await interaction.reply({
-        embeds: [
-          {
-            color: COLORS.PRIMARY,
-            description: `Match-match topic created successfully\n\nTopic\`\`\`\n${topic}\n\`\`\``,
-          },
-        ],
-        ephemeral: true,
-      });
-    } else {
-      await interaction.reply({
-        embeds: [
-          {
-            color: COLORS.PRIMARY,
-            description: 'Failed to create match-match topic',
-          },
-        ],
-        ephemeral: true,
-      });
+    if (entries.length === 0) {
+      await replyWithEmbed(interaction, 'No topic was submitted, put at least one topic per line.');
+      return;
     }
+
+    const existingTopics = await MatchMatchTopic.find({}, 'topic').lean();
+    const existingKeys = new Set(existingTopics.map(({ topic }) => topic.trim().toLowerCase()));
+
+    const newTopics = entries.filter((topic) => !existingKeys.has(topic.toLowerCase()));
+    const alreadyExistingCount = entries.length - newTopics.length;
+
+    if (newTopics.length === 0) {
+      await replyWithEmbed(
+        interaction,
+        `No match-match topic created, all ${entries.length} submitted topic(s) already exist.`,
+      );
+      return;
+    }
+
+    const res = await MatchMatchTopic.insertMany(newTopics.map((topic) => ({ topic })));
+
+    if (!res || res.length === 0) {
+      await replyWithEmbed(interaction, 'Failed to create match-match topic(s)');
+      return;
+    }
+
+    const skippedNotes = [];
+    if (duplicateInInputCount > 0) {
+      skippedNotes.push(`${duplicateInInputCount} duplicate line(s) in your input`);
+    }
+    if (alreadyExistingCount > 0) {
+      skippedNotes.push(`${alreadyExistingCount} topic(s) that already exist`);
+    }
+
+    const skippedText = skippedNotes.length > 0 ? `\n\nSkipped ${skippedNotes.join(' and ')}.` : '';
+
+    await replyWithEmbed(
+      interaction,
+      `${res.length} match-match topic(s) created successfully\n\nTopics${formatBulkList(
+        newTopics,
+      )}${skippedText}`,
+    );
   } catch (error) {
-    // eslint-disable-next-line no-console
+    
     console.error(error);
-    await interaction.reply({
-      embeds: [
-        {
-          color: COLORS.PRIMARY,
-          description: 'Failed to create match-match topic (Internal Server Error)',
-        },
-      ],
-      ephemeral: true,
-    });
+    await replyWithEmbed(
+      interaction,
+      'Failed to create match-match topic(s) (Internal Server Error)',
+    );
   }
 };

--- a/src/service/interaction/is-modal-submit/create-new-category.js
+++ b/src/service/interaction/is-modal-submit/create-new-category.js
@@ -1,48 +1,79 @@
 import { COLORS } from '../../../constants/index.js';
 import A_TO_Z from '../../../data/a2z.js';
 import Category from '../../../models/category.js';
+import { formatBulkList, parseBulkLines } from '../../utils/parse-bulk-lines.js';
+
+const replyWithEmbed = (interaction, description) =>
+  interaction.reply({
+    embeds: [
+      {
+        color: COLORS.PRIMARY,
+        description,
+      },
+    ],
+    ephemeral: true,
+  });
 
 export default async (interaction) => {
   try {
-    const message = interaction.fields.getTextInputValue('message');
+    const input = interaction.fields.getTextInputValue('message');
+    const { entries, duplicateInInputCount } = parseBulkLines(input);
 
-    const res = await Category.create({
-      message,
-      alphabet: A_TO_Z,
-    });
-
-    if (res) {
-      await interaction.reply({
-        embeds: [
-          {
-            color: COLORS.PRIMARY,
-            description: `Category created successfully\n\nMessage\`\`\`\n${message}\n\`\`\``,
-          },
-        ],
-        ephemeral: true,
-      });
-    } else {
-      await interaction.reply({
-        embeds: [
-          {
-            color: COLORS.PRIMARY,
-            description: 'Failed to create category',
-          },
-        ],
-        ephemeral: true,
-      });
+    if (entries.length === 0) {
+      await replyWithEmbed(
+        interaction,
+        'No category was submitted, put at least one category per line.',
+      );
+      return;
     }
+
+    const existingCategories = await Category.find({}, 'message').lean();
+    const existingKeys = new Set(
+      existingCategories.map(({ message }) => message.trim().toLowerCase()),
+    );
+
+    const newMessages = entries.filter((message) => !existingKeys.has(message.toLowerCase()));
+    const alreadyExistingCount = entries.length - newMessages.length;
+
+    if (newMessages.length === 0) {
+      await replyWithEmbed(
+        interaction,
+        `No category created, all ${entries.length} submitted category (categories) already exist.`,
+      );
+      return;
+    }
+
+    const res = await Category.insertMany(
+      newMessages.map((message) => ({ message, alphabet: A_TO_Z })),
+    );
+
+    if (!res || res.length === 0) {
+      await replyWithEmbed(interaction, 'Failed to create category (categories)');
+      return;
+    }
+
+    const skippedNotes = [];
+    if (duplicateInInputCount > 0) {
+      skippedNotes.push(`${duplicateInInputCount} duplicate line(s) in your input`);
+    }
+    if (alreadyExistingCount > 0) {
+      skippedNotes.push(`${alreadyExistingCount} category (categories) that already exist`);
+    }
+
+    const skippedText = skippedNotes.length > 0 ? `\n\nSkipped ${skippedNotes.join(' and ')}.` : '';
+
+    await replyWithEmbed(
+      interaction,
+      `${res.length} category (categories) created successfully\n\nMessages${formatBulkList(
+        newMessages,
+      )}${skippedText}`,
+    );
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
-    await interaction.reply({
-      embeds: [
-        {
-          color: COLORS.PRIMARY,
-          description: 'Failed to create category (Internal Server Error)',
-        },
-      ],
-      ephemeral: true,
-    });
+    await replyWithEmbed(
+      interaction,
+      'Failed to create category (categories) (Internal Server Error)',
+    );
   }
 };

--- a/src/service/utils/parse-bulk-lines.js
+++ b/src/service/utils/parse-bulk-lines.js
@@ -23,13 +23,11 @@ export const parseBulkLines = (raw) => {
   return { entries, duplicateInInputCount };
 };
 
-
 export const formatBulkList = (entries) => {
   const lines = entries.map((entry, index) => `${index + 1}. ${entry}`);
 
   let content = '';
   let shownCount = 0;
-
 
   for (const line of lines) {
     if (content.length + line.length + 1 > MAX_CODE_BLOCK_LENGTH) break;

--- a/src/service/utils/parse-bulk-lines.js
+++ b/src/service/utils/parse-bulk-lines.js
@@ -1,0 +1,48 @@
+const MAX_CODE_BLOCK_LENGTH = 3000;
+
+export const parseBulkLines = (raw) => {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const seen = new Set();
+  const entries = [];
+  let duplicateInInputCount = 0;
+
+  lines.forEach((line) => {
+    const key = line.toLowerCase();
+    if (seen.has(key)) {
+      duplicateInInputCount += 1;
+      return;
+    }
+    seen.add(key);
+    entries.push(line);
+  });
+
+  return { entries, duplicateInInputCount };
+};
+
+
+export const formatBulkList = (entries) => {
+  const lines = entries.map((entry, index) => `${index + 1}. ${entry}`);
+
+  let content = '';
+  let shownCount = 0;
+
+
+  for (const line of lines) {
+    if (content.length + line.length + 1 > MAX_CODE_BLOCK_LENGTH) break;
+    content += `${line}\n`;
+    shownCount += 1;
+  }
+
+  const remainingCount = entries.length - shownCount;
+  if (remainingCount > 0) {
+    content += `...and ${remainingCount} more\n`;
+  }
+
+  return `\`\`\`\n${content}\`\`\``;
+};
+
+export default parseBulkLines;


### PR DESCRIPTION
- Add support for creating multiple topics from a single modal submission (one per line)
- Trim input, ignore blank lines, and deduplicate entries within the same request
- Batch insert new topics with insertMany() to reduce database round trips
- Report created topics, skipped duplicates, and existing topics in the response
- Limit bulk list output with formatBulkList to prevent Discord embed length issues
- Refactor repeated interaction.reply() calls into a replyWithEmbed helper
- Update modal labels, placeholders, and slash command descriptions to indicate one-topic-per-line input