### PR TITLE
fix: calendar daily refresh, leaderboard top 10, alphabetical calendar

### DIFF
--- a/src/service/utils/event-calendar.js
+++ b/src/service/utils/event-calendar.js
@@ -77,31 +77,34 @@ export async function refreshEventCalendar() {
     const channel = await client.channels.fetch(calendarChannelId).catch(() => null);
     if (!channel) return;
 
-    // Delete existing bot messages
+    // Delete existing bot messages — individual deletes to avoid bulkDelete's 14-day limit
     const messages = await channel.messages.fetch({ limit: 100 });
     const botMessages = messages.filter((m) => m.author.id === client.user.id);
-
-    if (botMessages.size > 0) {
-      try {
-        await channel.bulkDelete(botMessages);
-      } catch {
-        for (const msg of botMessages.values()) {
-          await msg.delete().catch(() => {});
-        }
-      }
+    for (const msg of botMessages.values()) {
+      await msg
+        .delete()
+        .catch((err) =>
+          console.error(`refreshEventCalendar: failed to delete message ${msg.id}:`, err.message),
+        );
     }
 
-    // Fetch active standard events
-    const events = await Event.find({ status: 'active' }).sort({ startDate: 1 });
+    // Fetch active standard events sorted alphabetically
+    const events = await Event.find({ status: 'active' }).sort({ name: 1 });
 
     // Only include live-event series with an occurrence scheduled for today.
-    const todayStr = formatDateUTC(new Date());
-    const liveEvents = (await LiveEvent.find({ status: { $in: ['upcoming', 'live'] } }))
-      .map((liveEvent) => ({
-        liveEvent,
-        occurrences: getOccurrencesOnDate(liveEvent, todayStr),
-      }))
-      .filter(({ occurrences }) => occurrences.length > 0);
+    // Wrapped separately so a live-event failure never blocks the standard embed.
+    let liveEvents = [];
+    try {
+      const todayStr = formatDateUTC(new Date());
+      liveEvents = (await LiveEvent.find({ status: { $in: ['upcoming', 'live'] } }))
+        .map((liveEvent) => ({
+          liveEvent,
+          occurrences: getOccurrencesOnDate(liveEvent, todayStr),
+        }))
+        .filter(({ occurrences }) => occurrences.length > 0);
+    } catch (liveErr) {
+      console.error('refreshEventCalendar: failed to fetch live events:', liveErr.message);
+    }
 
     await channel.send({
       embeds: [buildStandardEmbed(events, liveEvents)],

--- a/src/service/utils/event-utils.js
+++ b/src/service/utils/event-utils.js
@@ -71,10 +71,10 @@ export function buildCalendarEmbed(event) {
 
 // ─── Live leaderboard embed builder ─────────────────────────────────────────
 
-const MEDALS = ['🥇', '🥈', '🥉'];
+const MEDALS = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟'];
 
 /**
- * Build the pinned leaderboard embed showing top 3 participants.
+ * Build the pinned leaderboard embed showing top 10 participants.
  * Sorted by points descending, then by earliest submission (createdAt ascending)
  * to break ties in favour of whoever reached that score first.
  */
@@ -85,9 +85,9 @@ export async function buildLiveLeaderboardEmbed(event) {
 
   const totalParticipants = await EventParticipant.countDocuments({ eventId });
 
-  const top3 = await EventParticipant.find({ eventId })
+  const top10 = await EventParticipant.find({ eventId })
     .sort({ points: -1, createdAt: 1 })
-    .limit(3)
+    .limit(10)
     .lean();
 
   const subtitle = event.pointsPerSubmission
@@ -95,10 +95,10 @@ export async function buildLiveLeaderboardEmbed(event) {
     : `Leaderboard · ${totalParticipants} participant${totalParticipants === 1 ? '' : 's'}`;
 
   let description;
-  if (top3.length === 0) {
+  if (top10.length === 0) {
     description = '*No submissions yet. Be the first!*';
   } else {
-    const rows = top3.map((p, i) =>
+    const rows = top10.map((p, i) =>
       event.pointsPerSubmission
         ? `${MEDALS[i]} <@${p.userId}> **${p.points}**`
         : `${MEDALS[i]} <@${p.userId}> ${p.submissionCount} submission${p.submissionCount === 1 ? '' : 's'}`,
@@ -137,13 +137,13 @@ export async function updateLiveLeaderboard(event) {
     const embed = await buildLiveLeaderboardEmbed(event);
     await message.edit({ embeds: [embed] });
 
-    // Lock once 3 participants have reached the max points cap
+    // Lock once 10 participants have reached the max points cap
     const maxedCount = await EventParticipant.countDocuments({
       eventId,
       points: event.maxPoints,
     });
 
-    if (maxedCount >= 3) {
+    if (maxedCount >= 10) {
       record.isLocked = true;
       await record.save();
     }
@@ -177,10 +177,7 @@ export function escapeRegex(value) {
 }
 
 export async function findByIdOrName(Model, selection) {
-  const normalizedSelection = selection.replace(
-    /\s+\[(?:Recurring|One-time)\s+·\s+[^\]]+\]$/,
-    '',
-  );
+  const normalizedSelection = selection.replace(/\s+\[(?:Recurring|One-time)\s+·\s+[^\]]+\]$/, '');
 
   if (mongoose.isValidObjectId(normalizedSelection)) {
     const byId = await Model.findById(normalizedSelection);


### PR DESCRIPTION
### Changes

1. Event leaderboard expanded to top 10 (event-utils.js)
  - Increased participant display from top 3 to top 10
  - Added number emojis 4️⃣–🔟 to the medals array
  - Updated the leaderboard lock threshold from 3 to 10

2. Calendar events alphabetised (event-calendar.js)
  - Changed sort from `startDate: 1` to `name: 1`

3. Fixed calendar embed not refreshing daily (event-calendar.js, index.js)

The bug was introduced when the live event feature added LiveEvent.find() inside refreshEventCalendar. If that query threw for any reason (model registration issue, missing collection on a fresh container, anything), it would be caught by the outer try/catch and the entire function would exit, meaning channel.send never ran and no embed was posted.

The fix isolates the live event fetch in its own try/catch so a failure there only logs an error and the standard calendar embed still posts regardless.

Additionally changed bulkDelete to individual deletes with error logging so delete failures are visible in logs and don't silently block the rest of the function. 

Closes #45 